### PR TITLE
Implement backtrace for exceptions in wpp::eval_ast

### DIFF
--- a/src/exception.hpp
+++ b/src/exception.hpp
@@ -4,6 +4,7 @@
 #define WOTPP_EXCEPTION
 
 #include <stdexcept>
+#include <vector>
 #include <string>
 
 #include <utils/util.hpp>
@@ -26,6 +27,24 @@ namespace wpp {
 		Exception():
 			std::runtime_error(DEFAULT_ERROR_MESSAGE),
 			pos() {}
+	};
+
+	// This is ugly. TODO: Separate header/implementation files
+	struct FnInvoke;
+	using Backtrace = std::vector<wpp::FnInvoke>;
+
+	struct BacktraceException: Exception {
+		wpp::Backtrace backtrace;
+
+		template <typename... Ts>
+		BacktraceException(const wpp::Backtrace& bt_, const wpp::Position& pos_, Ts&&... args):
+			Exception(pos_, args...), backtrace(bt_) {}
+
+		BacktraceException(const wpp::Backtrace& bt_, const wpp::Position& pos_):
+			Exception(pos_), backtrace(bt_) {}
+
+		BacktraceException(const wpp::Backtrace& bt_):
+			Exception(), backtrace(bt_) {}
 	};
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,9 +25,17 @@ int main(int argc, const char* argv[]) {
 	auto file = wpp::read_file(argv[1]);
 
 	wpp::Environment env;
+	wpp::Backtrace bt;
 
 	try {
-		std::cout << wpp::eval(file, env) << std::endl;
+		std::cout << wpp::eval(file, env, bt) << std::endl;
+	}
+
+	catch (const wpp::BacktraceException& e) {
+		std::cout << "Document backtrace:" << std::endl;
+		wpp::print_backtrace(e.backtrace);
+		wpp::error(e.pos, e.what());
+		return 1;
 	}
 
 	catch (const wpp::Exception& e) {

--- a/src/utils/util.hpp
+++ b/src/utils/util.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <stdexcept>
 #include <array>
+#include <vector>
 #include <utility>
 // #include <filesystem>
 #include <iostream>
@@ -125,6 +126,13 @@ namespace wpp {
 		([&] () -> std::ostream& {
 			return (std::cerr << "error @ " << first << " -> ");
 		} () << ... << std::forward<Ts>(args)) << '\n';
+	}
+
+	template <typename T>
+	constexpr void print_backtrace(const T& backtrace) {
+		int i = 1;
+		for(auto& call: backtrace)
+			std::cerr << "#" << i++ << ": " << call.identifier << " @ " << call.pos << std::endl;
 	}
 }
 

--- a/src/visitors/eval.hpp
+++ b/src/visitors/eval.hpp
@@ -19,11 +19,7 @@ namespace wpp {
 	using Environment = std::unordered_map<std::string, wpp::node_t>;
 	using Arguments = std::unordered_map<std::string, std::string>;
 
-
-	// TODO: Separate this into a header/implementation file so we don't have to forward declare this
-	inline std::string eval(const std::string& code, wpp::Environment& env);
-
-	inline std::string eval_ast(const wpp::node_t node_id, wpp::AST& tree, Environment& functions, Arguments* args = nullptr) {
+	inline std::string eval_ast(const wpp::node_t node_id, wpp::AST& tree, Environment& functions, Backtrace backtrace, Arguments* args = nullptr) {
 		const auto& variant = tree[node_id];
 		std::string str;
 
@@ -31,25 +27,37 @@ namespace wpp {
 			[&] (const FnRun& run) {
 				const auto& [arg, pos] = run;
 
-				auto cmd = eval_ast(arg, tree, functions, args);
+				auto cmd = eval_ast(arg, tree, functions, backtrace, args);
 				str = wpp::exec(cmd);
 			},
 
 			[&] (const FnEval& eval) {
 				const auto& [arg, pos] = eval;
 
-				auto code = eval_ast(arg, tree, functions, args);
+				auto code = eval_ast(arg, tree, functions, backtrace, args);
 
 				wpp::Lexer lex{code.c_str()};
 				wpp::node_t root;
+				wpp::Backtrace bt; // create an individual backtrace for every eval
 
 				try {
 					root = document(lex, tree);
-					str = wpp::eval_ast(root, tree, functions, args);
+					str = wpp::eval_ast(root, tree, functions, bt, args);
+				}
+
+				catch (const wpp::BacktraceException& e) {
+					// We caught a backtrace exception, print the backtrace's exception and throw our own backtrace for the upper-level eval to handle
+					if(!e.backtrace.empty()) {
+						std::cerr << "Eval backtrace @ " << eval.pos << ":" << std::endl;
+						wpp::print_backtrace(e.backtrace);
+					}
+
+					throw wpp::BacktraceException{backtrace, pos, "inside eval: ", e.what()};
 				}
 
 				catch (const wpp::Exception& e) {
-					throw wpp::Exception{ pos, "inside eval: ", e.what() };
+					// We caught a generic exception, throw that with backtrace for the upper-level eval to handle (we are the lowermost level)
+					throw wpp::BacktraceException{backtrace, pos, "inside eval: ", e.what()};
 				}
 			},
 
@@ -73,10 +81,13 @@ namespace wpp {
 					}
 				}
 
+				// Add it to the backtrace
+				backtrace.push_back(call);
+
 				// If it wasn't a parameter, we fall through to here and check if it's a function.
 				auto it = functions.find(caller_mangled_name);
 				if (it == functions.end())
-					throw wpp::Exception{caller_pos, "func not found: ", caller_name};
+					throw wpp::BacktraceException{backtrace, caller_pos, "func not found: ", caller_name};
 
 				// Retrieve function.
 				const auto& [callee_name, params, body, callee_pos] = tree.get<wpp::Fn>(it->second);
@@ -86,10 +97,10 @@ namespace wpp {
 
 				// Evaluate arguments and store their result.
 				for (int i = 0; i < (int)caller_args.size(); i++)
-					env_args.emplace(params[i], eval_ast(caller_args[i], tree, functions, args));
+					env_args.emplace(params[i], eval_ast(caller_args[i], tree, functions, backtrace, args));
 
 				// Call function.
-				str = eval_ast(body, tree, functions, &env_args);
+				str = eval_ast(body, tree, functions, backtrace, &env_args);
 			},
 
 			[&] (const Fn& func) {
@@ -103,17 +114,17 @@ namespace wpp {
 
 			[&] (const Concat& cat) {
 				const auto& [lhs, rhs, pos] = cat;
-				str = eval_ast(lhs, tree, functions, args) + eval_ast(rhs, tree, functions, args);
+				str = eval_ast(lhs, tree, functions, backtrace, args) + eval_ast(rhs, tree, functions, backtrace, args);
 			},
 
 			[&] (const Block& block) {
 				const auto& [stmts, expr, pos] = block;
 
 				for (const wpp::node_t node: stmts) {
-					str += eval_ast(node, tree, functions, args);
+					str += eval_ast(node, tree, functions, backtrace, args);
 				}
 
-				str = eval_ast(expr, tree, functions, args);
+				str = eval_ast(expr, tree, functions, backtrace, args);
 			},
 
 			[&] (const Ns&) {
@@ -122,7 +133,7 @@ namespace wpp {
 
 			[&] (const Document& doc) {
 				for (const wpp::node_t node: doc.stmts) {
-					str += eval_ast(node, tree, functions, args);
+					str += eval_ast(node, tree, functions, backtrace, args);
 				}
 			}
 		);
@@ -130,7 +141,7 @@ namespace wpp {
 		return str;
 	}
 
-	inline std::string eval(const std::string& code, wpp::Environment& env) {
+	inline std::string eval(const std::string& code, wpp::Environment& env, wpp::Backtrace backtrace) {
 		// Create a new lexer and syntax tree
 		wpp::Lexer lex{code.c_str()};
 		wpp::AST tree;
@@ -142,7 +153,7 @@ namespace wpp {
 		auto root = document(lex, tree);
 
 		// Evaluate.
-		return wpp::eval_ast(root, tree, env);
+		return wpp::eval_ast(root, tree, env, backtrace);
 	}
 
 }


### PR DESCRIPTION
The code could really be cleaned up by separating it into header/implementation files.
I've had to work around circular dependencies by templating wpp::print_backtrace, etc.