### PR TITLE
Separate variables from functions.

### DIFF
--- a/src/backend/eval/intrinsics.cpp
+++ b/src/backend/eval/intrinsics.cpp
@@ -32,7 +32,7 @@ namespace wpp {
 		wpp::Env& env,
 		wpp::FnEnv* fn_env
 	) {
-		const auto& [ast, functions, positions, root, flags, sources] = env;
+		const auto& [ast, functions, variables, positions, root, flags, sources] = env;
 
 		#if defined(WPP_DISABLE_RUN)
 			wpp::error(positions[node_id], env, "run not available.");
@@ -63,7 +63,7 @@ namespace wpp {
 		wpp::Env& env,
 		wpp::FnEnv* fn_env
 	) {
-		const auto& [ast, functions, positions, root, flags, sources] = env;
+		const auto& [ast, functions, variables, positions, root, flags, sources] = env;
 
 		#if defined(WPP_DISABLE_RUN)
 			wpp::error(positions[node_id], env, "pipe not available.");
@@ -97,7 +97,7 @@ namespace wpp {
 		wpp::Env& env,
 		wpp::FnEnv* fn_env
 	) {
-		const auto& [ast, functions, positions, root, warning_flags, sources] = env;
+		const auto& [ast, functions, variables, positions, root, warning_flags, sources] = env;
 
 		const auto fname = wpp::evaluate(exprs[0], env, fn_env);
 
@@ -119,7 +119,7 @@ namespace wpp {
 		wpp::Env& env,
 		wpp::FnEnv* fn_env
 	) {
-		const auto& [ast, functions, positions, root, warning_flags, sources] = env;
+		const auto& [ast, functions, variables, positions, root, warning_flags, sources] = env;
 
 		std::string str;
 		const auto fname = wpp::evaluate(exprs[0], env, fn_env);
@@ -153,7 +153,7 @@ namespace wpp {
 		wpp::Env& env,
 		wpp::FnEnv* fn_env
 	) {
-		const auto& [ast, functions, positions, root, warning_flags, sources] = env;
+		const auto& [ast, functions, variables, positions, root, warning_flags, sources] = env;
 
 		// Check if strings are equal.
 		const auto str_a = evaluate(exprs[0], env, fn_env);
@@ -172,7 +172,7 @@ namespace wpp {
 		wpp::Env& env,
 		wpp::FnEnv* fn_env
 	) {
-		const auto& [ast, functions, positions, root, warning_flags, sources] = env;
+		const auto& [ast, functions, variables, positions, root, warning_flags, sources] = env;
 
 		const auto msg = evaluate(exprs[0], env, fn_env);
 		wpp::error(positions[node_id], env, msg);
@@ -224,7 +224,7 @@ namespace wpp {
 		wpp::Env& env,
 		wpp::FnEnv* fn_env
 	) {
-		const auto& [ast, functions, positions, root, warning_flags, sources] = env;
+		const auto& [ast, functions, variables, positions, root, warning_flags, sources] = env;
 
 		// Evaluate arguments
 		const auto string = evaluate(exprs[0], env, fn_env);

--- a/src/misc/util/util.hpp
+++ b/src/misc/util/util.hpp
@@ -77,7 +77,7 @@ namespace wpp {
 	template <typename... Ts>
 	inline void print_error(const char* const type, const wpp::Pos& pos, const wpp::Env& env, Ts&&... args) {
 		([&] () -> std::ostream& {
-			const auto& [ast, functions, positions, root, warning_flags, sources] = env;
+			const auto& [ast, functions, variables, positions, root, warning_flags, sources] = env;
 			const auto& [source, offset] = pos;
 			const auto& [file, base, mode] = source;
 

--- a/src/structures/environment.hpp
+++ b/src/structures/environment.hpp
@@ -40,6 +40,7 @@ namespace wpp {
 
 
 	using Functions = std::unordered_map<std::string, std::vector<wpp::node_t>>;
+	using Variables = std::unordered_map<std::string, std::vector<std::string>>;
 	using Arguments = std::unordered_map<wpp::View, std::string>;
 	using Positions = std::vector<wpp::Pos>;
 
@@ -73,6 +74,7 @@ namespace wpp {
 		wpp::AST ast{};
 
 		wpp::Functions functions{};
+		wpp::Variables variables{};
 		wpp::Positions positions{};
 
 		const std::filesystem::path root{};

--- a/tests/var.wpp
+++ b/tests/var.wpp
@@ -2,3 +2,16 @@
 var foo "hey"
 var foo foo .. "hey"
 foo
+
+let defoo(x) {
+    var foo x
+    ""
+}
+
+#[expect(hi)]
+defoo("hi")
+foo
+
+#[expect(bye)]
+defoo("bye")
+foo


### PR DESCRIPTION
- The AST is not longer modified from the declaration of a variable.
- Fixes #66.
- The code needs a lot of cleanup, I especially don't like how the part
  to find funcs/vars in the environment looks.